### PR TITLE
[internal] add kube-rbac-proxy liveness/readyness probes

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -4,9 +4,6 @@ linters-settings:
       liveness-probe:
         - kind: Deployment
           name: snapshot-controller
-          container: kube-rbac-proxy
-        - kind: Deployment
-          name: snapshot-controller
           container: snapshot-controller
         - kind: Deployment
           name: snapshot-controller
@@ -15,9 +12,6 @@ linters-settings:
           name: snapshot-validation-webhook
           container: snapshot-validation
       readiness-probe:
-        - kind: Deployment
-          name: snapshot-controller
-          container: kube-rbac-proxy
         - kind: Deployment
           name: snapshot-controller
           container: snapshot-controller

--- a/templates/snapshot-controller/deployment.yaml
+++ b/templates/snapshot-controller/deployment.yaml
@@ -93,6 +93,16 @@ spec:
         ports:
         - containerPort: 8080
           name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
         env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add kube-rbac-proxy liveness/readyness probes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct module templates

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
