### PR TITLE
[internal] remove unnecessary annotations from alerts

### DIFF
--- a/monitoring/prometheus-rules/snapshot-controller.yaml
+++ b/monitoring/prometheus-rules/snapshot-controller.yaml
@@ -67,7 +67,6 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_labels_as_annotations: "pod"
         plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Snapshot-controller Pod is NOT Ready.

--- a/monitoring/prometheus-rules/snapshot-validation-webhook.yaml
+++ b/monitoring/prometheus-rules/snapshot-validation-webhook.yaml
@@ -9,7 +9,6 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_labels_as_annotations: "pod"
         plk_create_group_if_not_exists__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Snapshot-validation-webhook Pod is NOT Ready.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

There is unnecessary annotations from alerts, for correct alert grouping

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct monitoring work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
