### PR TITLE
[internal] Allow empty PersistentVolumeClaimName (need for pre-provisioned snapshots)

### DIFF
--- a/images/webhooks/handlers/volumeSnapshotMutator.go
+++ b/images/webhooks/handlers/volumeSnapshotMutator.go
@@ -70,8 +70,8 @@ func VolumeSnapshotMutate(ctx context.Context, _ *model.AdmissionReview, obj met
 	}
 
 	if snapshot.Spec.Source.PersistentVolumeClaimName == nil {
-		log.Error("VolumeSnapshotMutate: VolumeSnapshot PersistentVolumeClaimName is nil", "snapshot", snapshot.Name)
-		return &kwhmutating.MutatorResult{}, errors.New("VolumeSnapshot PersistentVolumeClaimName is nil")
+		log.Warn("VolumeSnapshotMutate: VolumeSnapshot PersistentVolumeClaimName is nil. Skipping mutation", "snapshot", snapshot.Name)
+		return &kwhmutating.MutatorResult{}, nil
 	}
 
 	namespace := snapshot.ObjectMeta.Namespace


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR removes the validation error that was raised when a
`VolumeSnapshot` spec did **not** contain the `persistentVolumeClaimName`
field.  An empty `persistentVolumeClaimName` is perfectly valid when the
snapshot was **pre-provisioned** (imported from an external source or
created outside of Kubernetes).  With the check removed, pre-provisioned
snapshots are accepted without forcing users to supply a PVC reference
that does not exist.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Snapshot-controller previously rejected manifests for legitimate pre-provisioned snapshots, producing a validation error. This prevented clusters from importing existing snapshots or restoring volumes from externally-created backups.  By allowing an empty value we align with the CSI Snapshot spec, which makes the field optional for the pre-provisioned use-case, and unblock those workflows.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

* Users can create `VolumeSnapshot` objects **without**
  `spec.persistentVolumeClaimName` when they intend to reference a
  pre-provisioned snapshot.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
