### PR TITLE
Change imagePullSecrets for webhooks

### DIFF
--- a/templates/registry-secret.yaml
+++ b/templates/registry-secret.yaml
@@ -2,6 +2,20 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ .Chart.Name }}-module-registry
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+type: kubernetes.io/dockerconfigjson
+data:
+{{- if dig "registry" "dockercfg" false .Values.snapshotController }}
+  .dockerconfigjson: {{ .Values.snapshotController.registry.dockercfg }}
+{{- else }}
+  .dockerconfigjson: "eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5pbyI6IHt9fX0="
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: deckhouse-registry
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}

--- a/templates/snapshot-controller/deployment.yaml
+++ b/templates/snapshot-controller/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         app: snapshot-controller
     spec:
       imagePullSecrets:
-        - name: deckhouse-registry
+        - {{ .Chart.Name }}-module-registry
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}

--- a/templates/snapshot-controller/deployment.yaml
+++ b/templates/snapshot-controller/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         app: snapshot-controller
     spec:
       imagePullSecrets:
-        - {{ .Chart.Name }}-module-registry
+        - name: {{ .Chart.Name }}-module-registry
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}

--- a/templates/snapshot-validation-webhook/deployment.yaml
+++ b/templates/snapshot-validation-webhook/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/snapshot-validation-webhook/secret.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
-        - name: deckhouse-registry
+        - name: {{ .Chart.Name }}-module-registry
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -104,7 +104,7 @@ spec:
 {{- end }}
 
       imagePullSecrets:
-        - name: {{ .Chart.Name }}-module-registry
+        - name: deckhouse-registry
       serviceAccount: webhooks
       serviceAccountName: webhooks
       volumes:

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -102,6 +102,7 @@ spec:
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             {{- include "webhooks_resources" . | nindent 12 }}
 {{- end }}
+
       imagePullSecrets:
         - name: {{ .Chart.Name }}-module-registry
       serviceAccount: webhooks

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -102,7 +102,6 @@ spec:
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             {{- include "webhooks_resources" . | nindent 12 }}
 {{- end }}
-
       imagePullSecrets:
         - name: {{ .Chart.Name }}-module-registry
       serviceAccount: webhooks

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -104,7 +104,7 @@ spec:
 {{- end }}
 
       imagePullSecrets:
-        - name: deckhouse-registry
+        - name: {{ .Chart.Name }}-module-registry
       serviceAccount: webhooks
       serviceAccountName: webhooks
       volumes:


### PR DESCRIPTION
## Description
Change imagePullSecrets for webhooks

## Why do we need it, and what problem does it solve?
Cause in kubelet we have some errors like
```
Jul 22 08:17:30 kovalkov-master-0 d8-kubelet-forker[687222]: I0722 08:17:30.836207  687222 kubelet_pods.go:1007] "Unable to retrieve pull secret, the image pull may not succeed." pod="d8-snapshot-controller/webhooks-5bbd79b86f-gfgtl" secret="" err="secret \"snapshot-controller-module-registry\" not found"
```

## What is the expected result?
Correct imagePullSecrets for webhooks

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
