### PR TITLE
[internal] force module enable state

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -9,7 +9,6 @@ descriptions:
   en: |
     This module enables snapshot support for compatible CSI-drivers in the Kubernetes cluster.
 requirements:
-  bootstrapped: true
   deckhouse: ">= 1.67"
 accessibility:
    editions:

--- a/module.yaml
+++ b/module.yaml
@@ -11,8 +11,8 @@ descriptions:
 requirements:
   deckhouse: ">= 1.67"
 accessibility:
-   editions:
-     _default:
+  editions:
+    _default:
       available: true
       enabledInBundles:
         - Default

--- a/module.yaml
+++ b/module.yaml
@@ -11,3 +11,10 @@ descriptions:
 requirements:
   bootstrapped: true
   deckhouse: ">= 1.67"
+accessibility:
+   editions:
+     _default:
+      available: true
+      enabledInBundles:
+        - Default
+        - Managed


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We need this module as required for many of other. So we force it enable state

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct cluster work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
