### PR TITLE
[templates] Add RBAC ClusterRoles for module CRDs

### DIFF
--- a/templates/rbac-for-us.yaml
+++ b/templates/rbac-for-us.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:snapshot-controller:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshotcontents
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:snapshot-controller:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:snapshot-controller:admin-kubeconfig
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: kubeadm:cluster-admins

--- a/templates/rbacv2/manage/edit.yaml
+++ b/templates/rbacv2/manage/edit.yaml
@@ -23,3 +23,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/templates/rbacv2/manage/view.yaml
+++ b/templates/rbacv2/manage/view.yaml
@@ -22,3 +22,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch

--- a/templates/rbacv2/use/edit.yaml
+++ b/templates/rbacv2/use/edit.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    heritage: deckhouse
+    module: snapshot-controller
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: manager
+    rbac.deckhouse.io/kind: use
+  name: d8:use:capability:module:snapshot-controller:edit
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/templates/rbacv2/use/view.yaml
+++ b/templates/rbacv2/use/view.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    heritage: deckhouse
+    module: snapshot-controller
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: viewer
+    rbac.deckhouse.io/kind: use
+  name: d8:use:capability:module:snapshot-controller:view
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch

--- a/templates/user-authz-cluster-roles.yaml
+++ b/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:snapshot-controller:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshotcontents
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterEditor
+  name: d8:user-authz:snapshot-controller:cluster-editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshotcontents
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update


### PR DESCRIPTION
## Description

Add RBAC `ClusterRole`s for the module CRDs in two complementary layers.

### 1. Current model — `templates/user-authz-cluster-roles.yaml`

`ClusterRole` annotated with `user-authz.deckhouse.io/access-level`. `user-authz` creates bindings for subjects of every `ClusterAuthorizationRule`/`AuthorizationRule` with the matching level.

- `User` — read-only (`get`/`list`/`watch`).
- `ClusterEditor` — full CRUD (`create`/`update`/`patch`/`delete`/`deletecollection`).

### 2. admin.conf — `templates/rbac-for-us.yaml`

- `ClusterRole d8:snapshot-controller:admin-kubeconfig` — full CRUD on the module CRDs.
- `ClusterRoleBinding d8:snapshot-controller:admin-kubeconfig` — to `Group/kubeadm:cluster-admins`.

Subjects authenticated through the cluster `admin.conf` get the same access as `ClusterEditor` on module resources without going through `user-authz`.

### 3. rbacv2 — `templates/rbacv2/`

`ClusterRole`s aggregated via labels into Deckhouse rbacv2 roles.

**manage** (cluster-scoped CRDs) — `templates/rbacv2/manage/`:

- `view.yaml` → `d8:manage:permission:module:snapshot-controller:view` with `rbac.deckhouse.io/aggregate-to-storage-as: viewer`, read verbs.
- `edit.yaml` → `d8:manage:permission:module:snapshot-controller:edit` with `rbac.deckhouse.io/aggregate-to-storage-as: manager`, write verbs.

**use** (namespaced CRDs) — `templates/rbacv2/use/`:

- `view.yaml` → `d8:use:capability:module:snapshot-controller:view` with `rbac.deckhouse.io/aggregate-to-kubernetes-as: viewer`, read verbs.
- `edit.yaml` → `d8:use:capability:module:snapshot-controller:edit` with `rbac.deckhouse.io/aggregate-to-kubernetes-as: manager`, write verbs.

### Covered resources

**Cluster-scoped** (via manage permissions):

- `volumesnapshotclasses`
- `volumesnapshotcontents`

**Namespaced** (via use capabilities):

- `volumesnapshots`

## Why do we need it, and what problem does it solve?

Exposes module CRDs to both Deckhouse RBAC layers so that the standard roles actually grant access to module resources:

- **user-authz layer** — subjects bound through `ClusterAuthorizationRule`/`AuthorizationRule` at the matching level (e.g. `User`, `ClusterEditor`) get the expected access automatically.
- **admin.conf layer** — `kubeadm:cluster-admins` group (used by the cluster `admin.conf`) is bound directly to the module's full-CRUD `ClusterRole`, bypassing `user-authz`.
- **rbacv2 layer** — aggregated roles `d8:manage:storage:*` (cluster-scoped) and `d8:use:kubernetes:*` (namespaced) pull the module permissions in via the aggregation labels.

## What is the expected result?

After applying, the following `ClusterRole`s are created:

- `d8:user-authz:snapshot-controller:user` (read)
- `d8:user-authz:snapshot-controller:cluster-editor` (CRUD)
- `ClusterRole d8:snapshot-controller:admin-kubeconfig` (CRUD)
- `ClusterRoleBinding d8:snapshot-controller:admin-kubeconfig` → `Group/kubeadm:cluster-admins`
- `d8:manage:permission:module:snapshot-controller:view`
- `d8:manage:permission:module:snapshot-controller:edit`
- `d8:use:capability:module:snapshot-controller:view`
- `d8:use:capability:module:snapshot-controller:edit`

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
