### PR TITLE
[werf] Expose DistroPackagesProxy and proxy envs at root

### DIFF
--- a/.werf/images.yaml
+++ b/.werf/images.yaml
@@ -5,7 +5,7 @@
 {{- range $path, $content := $ImagesBuildFiles  }}
   {{- $ctx := dict }}
   {{- $_ := set $ctx "ImageName" ($path | split "/")._1 }}
-  {{- $_ := set $ctx "SOURCE_REPO" (env "SOURCE_REPO" "https://github.com") }}
+  {{- $_ := set $ctx "SOURCE_REPO" $Root.SOURCE_REPO }}
   {{- $_ := set $ctx "MODULE_EDITION" $.MODULE_EDITION }}
   {{- $_ := set $ctx "SVACE_ENABLED" (env "SVACE_ENABLED" "false") }}
   {{- $_ := set $ctx "SVACE_PROJECT_PREFIX" "snapshot-controller" }}
@@ -16,7 +16,8 @@
   {{- $_ := set $ctx "ImagePath" (printf "/images/%s" $ctx.ImageName) }}
   {{- $_ := set $ctx "ModuleNamePrefix" "" }}
   {{- $_ := set $ctx "ModuleDir" "/" }}
-  {{- $_ := set $ctx "GOPROXY" (env "GOPROXY" "https://proxy.golang.org,direct") }}
+  {{- $_ := set $ctx "GOPROXY" $Root.GOPROXY }}
+  {{- $_ := set $ctx "DistroPackagesProxy" $Root.DistroPackagesProxy }}
   {{- $_ := set $ctx "Commit" $Root.Commit }}
   {{- $_ := set $ctx "ProjectName" (printf "%s/%s" $ctx.SVACE_PROJECT_PREFIX $ctx.ImageName ) }}
   {{- $_ := set $ctx "Files" $.Files }}

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -7,6 +7,7 @@ config:
       - WERF_DISABLE_META_TAGS
       - GOPROXY
       - SOURCE_REPO
+      - DISTRO_PACKAGES_PROXY
       - MODULE_EDITION
       - SVACE_ENABLED
       - SVACE_ANALYZE_HOST

--- a/werf.yaml
+++ b/werf.yaml
@@ -9,6 +9,9 @@ build:
       removeLabels:
         - /.*/
 ---
+{{- $_ := set . "DistroPackagesProxy" (env "DISTRO_PACKAGES_PROXY" "") }}
+{{- $_ := set . "SOURCE_REPO" (env "SOURCE_REPO" "https://github.com") }}
+{{- $_ := set . "GOPROXY" (env "GOPROXY" "https://proxy.golang.org,direct") }}
 {{ tpl (.Files.Get ".werf/base-images.yaml") $ }}
 {{ tpl (.Files.Get ".werf/consts.yaml") $ }}
 {{ tpl (.Files.Get ".werf/choose-edition.yaml") $ }}


### PR DESCRIPTION
## Description

Expose `DISTRO_PACKAGES_PROXY`, `SOURCE_REPO`, and `GOPROXY` on the root werf context **before** any `tpl(.Files.Get …)` includes; pass `DistroPackagesProxy` (with `SOURCE_REPO` / `GOPROXY`) into each image’s `$ctx` in `.werf/images.yaml`; allow `DISTRO_PACKAGES_PROXY` in `werf-giterminism.yaml` `goTemplateRendering.allowEnvVariables`.

## Why do we need it, and what problem does it solve?

Aligns the module with the CSE external-module werf checklist so closed-loop / proxy settings can be supplied consistently at template render time (same pattern as the integration guide: root env → build context → giterminism).

## What is the expected result?

Werf config rendering and CI builds accept `DISTRO_PACKAGES_PROXY` without giterminism violations; image `werf.inc.yaml` templates receive `.DistroPackagesProxy` in `$ctx` when referenced.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.