### PR TITLE
[werf] Sync packages-proxies.tmpl with upstream Deckhouse

### DIFF
--- a/.werf/defines/packages-proxies.tmpl
+++ b/.werf/defines/packages-proxies.tmpl
@@ -1,6 +1,17 @@
 
 {{- define "alt packages proxy" }}
+# Replace altlinux repos with our proxy
+  {{- if $.DistroPackagesProxy }}
+- sed -i "s|ftp.altlinux.org/pub/distributions/archive|{{ $.DistroPackagesProxy }}/repository/archive-ALT-Linux-APT-Repository|g" /etc/apt/sources.list.d/alt.list
+  {{- end }}
+- export DEBIAN_FRONTEND=noninteractive
+- apt-get update -y
 {{- end }}
 
 {{- define "alpine packages proxy" }}
+# Replace alpine repos with our proxy
+  {{- if $.DistroPackagesProxy }}
+- sed -i 's|https://dl-cdn.alpinelinux.org|http://{{ $.DistroPackagesProxy }}/repository|g' /etc/apk/repositories
+  {{- end }}
+- apk update
 {{- end }}


### PR DESCRIPTION
## Description

Sync `.werf/defines/packages-proxies.tmpl` with the canonical Deckhouse template so that `alt packages proxy` and `alpine packages proxy` are no longer empty stubs.

Source: https://github.com/deckhouse/deckhouse/blob/main/.werf/defines/packages-proxies.tmpl

Only the templates that this module actually `include`s are kept (`alt packages proxy` and `alpine packages proxy`); other distros from upstream (debian/ubuntu/node/yarn3/pypi) are not used here and were intentionally omitted.

## Why do we need it, and what problem does it solve?

The local `packages-proxies.tmpl` defined both helpers as empty `{{- define ... }}{{- end }}`, so:

- When `DISTRO_PACKAGES_PROXY` is set in the build environment, the package mirrors were not being rewritten to the internal proxy, even though `werf-giterminism.yaml` already allows the `DISTRO_PACKAGES_PROXY` env / secret. This made builds slower and dependent on upstream repo availability instead of using the configured proxy.
- `apt-get update` / `apk update` were not encapsulated in the helper, while in the upstream Deckhouse contract they are.

This PR aligns the module with the rest of the Deckhouse codebase so that the `DISTRO_PACKAGES_PROXY` contract works here the same way.

## What is the expected result?

- When `DISTRO_PACKAGES_PROXY` is set, ALT Linux apt sources and Alpine apk repositories are rewritten to the internal proxy before `apt-get update` / `apk update` runs.
- When it is unset, behavior is unchanged, except that `apt-get update -y` / `apk update` is now executed from inside the helper as well (matching upstream Deckhouse).
- No runtime / image content changes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
