### PR TITLE
feat: gate all templates on storage-foundation not being enabled

### DIFF
--- a/templates/monitoring.yaml
+++ b/templates/monitoring.yaml
@@ -1,1 +1,3 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 {{- include "helm_lib_prometheus_rules" (list . "d8-monitoring") }}
+{{- end }}

--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -5,3 +6,4 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}
+{{- end }}

--- a/templates/rbac-for-us.yaml
+++ b/templates/rbac-for-us.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,3 +35,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: kubeadm:cluster-admins
+{{- end }}

--- a/templates/rbac-to-us.yaml
+++ b/templates/rbac-to-us.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -29,4 +30,5 @@ subjects:
 - kind: ServiceAccount
   name: prometheus
   namespace: d8-monitoring
+{{- end }}
 {{- end }}

--- a/templates/rbacv2/manage/edit.yaml
+++ b/templates/rbacv2/manage/edit.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -34,3 +35,4 @@ rules:
   - deletecollection
   - patch
   - update
+{{- end }}

--- a/templates/rbacv2/manage/view.yaml
+++ b/templates/rbacv2/manage/view.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -31,3 +32,4 @@ rules:
   - get
   - list
   - watch
+{{- end }}

--- a/templates/rbacv2/use/edit.yaml
+++ b/templates/rbacv2/use/edit.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,3 +19,4 @@ rules:
   - deletecollection
   - patch
   - update
+{{- end }}

--- a/templates/rbacv2/use/view.yaml
+++ b/templates/rbacv2/use/view.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,3 +17,4 @@ rules:
   - get
   - list
   - watch
+{{- end }}

--- a/templates/registry-secret.yaml
+++ b/templates/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: v1
 kind: Secret
@@ -22,3 +23,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+{{- end }}

--- a/templates/snapshot-controller/deployment.yaml
+++ b/templates/snapshot-controller/deployment.yaml
@@ -3,6 +3,7 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -129,3 +130,4 @@ spec:
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
             {{- end }}
       serviceAccountName: snapshot-controller
+{{- end }}

--- a/templates/snapshot-controller/podmonitor.yaml
+++ b/templates/snapshot-controller/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -34,4 +35,5 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}
+{{- end }}
 {{- end }}

--- a/templates/snapshot-controller/rbac-for-us.yaml
+++ b/templates/snapshot-controller/rbac-for-us.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -93,3 +94,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: d8:rbac-proxy
+{{- end }}

--- a/templates/user-authz-cluster-roles.yaml
+++ b/templates/user-authz-cluster-roles.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -38,3 +39,4 @@ rules:
   - deletecollection
   - patch
   - update
+{{- end }}

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -2,7 +2,8 @@
 cpu: 10m
 memory: 50Mi
 {{- end }}
-  
+
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -111,3 +112,4 @@ spec:
         - name: webhook-certs
           secret:
             secretName: webhooks-https-certs
+{{- end }}

--- a/templates/webhooks/rbac-for-us.yaml
+++ b/templates/webhooks/rbac-for-us.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -48,3 +49,4 @@ subjects:
   - kind: ServiceAccount
     name: webhooks
     namespace: d8-{{ .Chart.Name }}
+{{- end }}

--- a/templates/webhooks/secret.yaml
+++ b/templates/webhooks/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: v1
 kind: Secret
@@ -10,3 +11,4 @@ data:
   ca.crt: {{ .Values.snapshotController.internal.customWebhookCert.ca | b64enc | quote }}
   tls.crt: {{ .Values.snapshotController.internal.customWebhookCert.crt | b64enc | quote }}
   tls.key: {{ .Values.snapshotController.internal.customWebhookCert.key | b64enc | quote }}
+{{- end }}

--- a/templates/webhooks/service.yaml
+++ b/templates/webhooks/service.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: v1
 kind: Service
@@ -14,3 +15,4 @@ spec:
       name: http
   selector:
     app: webhooks
+{{- end }}

--- a/templates/webhooks/webhook.yaml
+++ b/templates/webhooks/webhook.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -24,3 +25,4 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
     timeoutSeconds: 10
+{{- end }}


### PR DESCRIPTION
## Description

Wrap every Helm template under `templates/` with

```yaml
{{- if not (.Values.global.enabledModules | has "storage-foundation") }}
... existing body ...
{{- end }}
```

so the chart renders zero manifests as soon as the `storage-foundation` module is enabled in `global.enabledModules`. Templates that contain `{{- define ... }}` helpers (`templates/snapshot-controller/deployment.yaml` and `templates/webhooks/deployment.yaml`) keep the `define` block outside the gate, so the helper stays available regardless of whether the body is rendered.

No manifest content was changed — only the surrounding `{{- if … }} … {{- end }}` was added. When `storage-foundation` is **not** in `global.enabledModules`, the chart renders byte-for-byte the same output as before; when it is, `helm template` produces an empty result. Both cases were verified locally with `helm template` against this branch.

## Why do we need it, and what problem does it solve?

We are migrating users from the `snapshot-controller` module to `storage-foundation`. The new module ships its own copies of the snapshot-controller `Deployment`, the webhooks `Deployment` / `Service` / `MutatingWebhookConfiguration`, the registry secret, the namespace and all RBAC. Without a hand-off mechanism, enabling `storage-foundation` while `snapshot-controller` is still on means:

* two `snapshot-controller` `Deployments` (in `d8-snapshot-controller` and `d8-storage-foundation`) competing for the same `VolumeSnapshot*` objects via separate leader-election leases;
* two `MutatingWebhookConfiguration`s mutating every `VolumeSnapshot` `CREATE`;
* clashing `ClusterRole`/`ClusterRoleBinding` names (`d8:snapshot-controller:admin-kubeconfig`, `d8:user-authz:snapshot-controller:*`, `d8:manage:permission:module:snapshot-controller:*`, `d8:use:capability:module:snapshot-controller:*`, `d8:snapshot-controller:snapshot-controller:runner`/`:rbac-proxy`) — these names are owned by this module, not by `storage-foundation`, so they wouldn't collide between releases, but they would also keep granting access to a controller that is no longer authoritative.

The companion PR https://github.com/deckhouse/storage-foundation/pull/21 brings the missing RBAC, CRDs, doc-ru and the `remove-finalizers-on-module-delete` hook into `storage-foundation`, so it is safe to let it take over.

This PR is the operator-facing piece of the migration: it lets an admin enable `storage-foundation` first and only then disable `snapshot-controller`, instead of having to do both at the exact same `deckhouse` reconciliation tick.

## What is the expected result?

* When `storage-foundation` is **not** in `.Values.global.enabledModules`, `helm template` of this chart produces the same set of manifests as before this PR (verified for the RBAC files explicitly; smoke-rendered for the rest).
* When `storage-foundation` **is** in `.Values.global.enabledModules`, `helm template` of this chart emits no manifests at all — verified locally:
  * the `snapshot-controller` `Deployment`, `PodDisruptionBudget`, `VerticalPodAutoscaler`, `PodMonitor` and `ServiceAccount` are not rendered;
  * the `webhooks` `Deployment`, `Service`, `Secret`, `MutatingWebhookConfiguration`, `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` are not rendered;
  * the namespace `d8-snapshot-controller`, the registry secrets, all RBAC roles and the user-authz / rbacv2 cluster roles are not rendered.
* Existing clusters that do not enable `storage-foundation` see no behavioural change.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.