### PR TITLE
fix: remove cluster-scoped VolumeSnapshotContents from User access level

### DIFF
--- a/templates/user-authz-cluster-roles.yaml
+++ b/templates/user-authz-cluster-roles.yaml
@@ -12,7 +12,6 @@ rules:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotclasses
-  - volumesnapshotcontents
   - volumesnapshots
   verbs:
   - get
@@ -32,6 +31,18 @@ rules:
   resources:
   - volumesnapshotclasses
   - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
   - volumesnapshots
   verbs:
   - create


### PR DESCRIPTION
## Summary

- The `User` access level (`user-authz.deckhouse.io/access-level: User`) in `user-authz-cluster-roles.yaml` granted read access to cluster-scoped `VolumeSnapshotContents`. Users with namespace-limited access (`limitNamespaces`) could read cluster-wide objects they shouldn't have access to.
- Removed `volumesnapshotcontents` from the User level; kept `volumesnapshotclasses` (users need to discover available classes) and namespaced `volumesnapshots`.
- Added full verb set (get/list/watch + create/delete/deletecollection/patch/update) for cluster-scoped resources in `ClusterEditor`, so it no longer depends on User-level inheritance for reading `volumesnapshotclasses` and `volumesnapshotcontents`. Write access to namespaced `volumesnapshots` is split into a separate rule.

Aligns with the RBACv2 model where `use` roles contain only namespaced resources and `manage` roles cover cluster-scoped ones.

## Test plan

- [ ] User with `limitNamespaces` cannot `kubectl get volumesnapshotcontents`
- [ ] User can `kubectl get volumesnapshotclasses` and `kubectl get volumesnapshots -n <ns>`
- [ ] ClusterEditor can `kubectl get/create/delete volumesnapshotclasses`
- [ ] ClusterEditor can `kubectl get/create/delete volumesnapshotcontents`
- [ ] ClusterEditor can `kubectl create/delete volumesnapshots -n <ns>`