### PR TITLE
chore(werf): migrate to container-base v1.1.2

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -15,3 +15,7 @@ linters-settings:
         - kind: Deployment
           name: snapshot-validation-webhook
           container: snapshot-validation
+  no-cyrillic:
+    exclude-rules:
+      directories:
+        - hack/

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.0.51"
+  BASE_IMAGES_VERSION: "v1.1.2"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request
@@ -122,7 +122,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   push:
     tags:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -82,7 +82,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -125,7 +125,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -168,7 +168,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -211,7 +211,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.0.51"
+  BASE_IMAGES_VERSION: "v1.1.2"
 on:
   push:
     tags:

--- a/.github/workflows/translate-changelog.yml
+++ b/.github/workflows/translate-changelog.yml
@@ -2,7 +2,7 @@ name: Translate Changelog and Create PR
 
 on:
   push:
-    # Запуск для всех веток при любом push
+    # Run for all branches on any push
 
 jobs:
   translate-and-pr:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+base_images.yml

--- a/.werf/base-images.yaml
+++ b/.werf/base-images.yaml
@@ -1,7 +1,7 @@
 # Base Images
 {{- $baseImages := .Files.Get "base_images.yml" | fromYaml }}
 {{- range $k, $v := $baseImages }}
-  {{ $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
+  {{- $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
   {{- if ne $k "REGISTRY_PATH" }}
     {{- $_ := set $baseImages $k $baseImagePath }}
   {{- end }}
@@ -9,11 +9,3 @@
 {{- $_ := unset $baseImages "REGISTRY_PATH" }}
 
 {{- $_ := set . "Images" $baseImages }}
-# base images artifacts
-{{- range $k, $v := .Images }}
----
-image: {{ $k }}
-from: {{ $v }}
-final: false
-{{- end }}
-

--- a/.werf/bundle.yaml
+++ b/.werf/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: docs-generator
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -25,7 +25,7 @@ shell:
 # Bundle image, stored in your.registry.io/modules/<module-name>:<semver>
 ---
 image: bundle
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 
 import:
   # Rendering .werf/images-digests.yaml is required!

--- a/.werf/choose-edition.yaml
+++ b/.werf/choose-edition.yaml
@@ -1,6 +1,6 @@
 ---
 image: choose-edition
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 fromCacheVersion: {{ div .Commit.Date.Unix (mul 60 60 24 30) }}
 
 git:

--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -13,9 +13,9 @@
 # Images Digest: a files with all image digests to be able to use them in helm templates of a module
 ---
 image: images-digests
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 import:
-  - image: tools/jq
+  - from: {{ index $.Images "jq" }}
     add: /usr/bin/jq
     to: /usr/bin/jq
     before: setup

--- a/.werf/images.yaml
+++ b/.werf/images.yaml
@@ -5,6 +5,7 @@
 {{- range $path, $content := $ImagesBuildFiles  }}
   {{- $ctx := dict }}
   {{- $_ := set $ctx "ImageName" ($path | split "/")._1 }}
+  {{- $_ := set $ctx "Images" $.Images }}
   {{- $_ := set $ctx "SOURCE_REPO" $Root.SOURCE_REPO }}
   {{- $_ := set $ctx "MODULE_EDITION" $.MODULE_EDITION }}
   {{- $_ := set $ctx "SVACE_ENABLED" (env "SVACE_ENABLED" "false") }}

--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -1,7 +1,7 @@
 # Release image, stored in your.registry.io/modules/<module-name>/release:<semver>
 ---
 image: release-channel-version-artifact
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 final: false
 git:
 - add: /
@@ -13,7 +13,7 @@ git:
     setup:
     - '**/*'
 import:
-  - image: tools/yq
+  - from: {{ index $.Images "yq" }}
     add: /usr/bin/yq
     to: /usr/bin/yq
     before: install
@@ -24,7 +24,7 @@ shell:
     - cp -f CHANGELOG/{{ env "MODULES_MODULE_TAG" "local" }}.yml /changelog.yaml || touch /changelog.yaml
 ---
 image: release-channel-version
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 import:
   - image: release-channel-version-artifact
     add: /

--- a/images/go-hooks/werf.inc.yaml
+++ b/images/go-hooks/werf.inc.yaml
@@ -1,30 +1,17 @@
 ---
-image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
+
 git:
   - add: {{ .ModuleDir }}/hooks/go
-    to: /src/hooks/go
+    to: /usr/src/app/hooks/go
     stageDependencies:
       install:
         - '**/go.mod'
         - '**/go.sum'
+      beforeSetup:
         - '**/*.go'
-
-shell:
-  install:
-    - echo "src artifact"
-
----
-image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
-final: false
-
-import:
-  - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-    add: /src
-    to: /usr/src/app
-    before: install
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -37,6 +24,8 @@ shell:
   install:
     - cd /usr/src/app/hooks/go
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
-    - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  beforeSetup:
     - |
+      cd /usr/src/app/hooks/go;
+      export CGO_ENABLED=0
       {{- include "image-build.build" (set $ "BuildCommand" `go build -a -gcflags=all="-l -B" -ldflags="-w -s" -o /go-hooks *.go;`) | nindent 6 }}

--- a/images/snapshot-controller/werf.inc.yaml
+++ b/images/snapshot-controller/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 # do not remove this image: used in external audits (DKP CSE)
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -30,7 +30,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
@@ -47,12 +47,13 @@ secrets:
   value: {{ .GOPROXY }}
 
 shell:
-{{- if eq .SVACE_ENABLED "false" }}
-  beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache make bash git
-{{- end }}
   install:
+    {{- if eq .SVACE_ENABLED "false" }}
+    - pm install git make bash
+    {{- else }}
+    {{- include "alpine packages proxy" $ | nindent 4 }}
+    - apk add --no-cache make bash git
+    {{- end }}
     - cd /src/snapshot-controller
     - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
@@ -64,7 +65,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
     add: /{{ $.ImageName }}

--- a/images/webhooks/werf.inc.yaml
+++ b/images/webhooks/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
+# do not remove this image: used in external audits (DKP CSE)
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -12,22 +13,22 @@ git:
       install:
         - '**/*'
     excludePaths:
-      - images/{{ $.ImageName }}/werf.yaml
+      - images/{{ $.ImageName }}/werf.inc.yaml
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src
     to: /src
-    before: install
+    before: setup
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -47,7 +48,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 git:
 {{- include "image mount points" . }}
@@ -56,7 +57,7 @@ import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
     add: /{{ $.ImageName }}
     to: /{{ $.ImageName }}
-    before: install
+    before: setup
 
 imageSpec:
   config:

--- a/templates/snapshot-controller/deployment.yaml
+++ b/templates/snapshot-controller/deployment.yaml
@@ -70,7 +70,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: snapshot-controller
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true "seccompProfile" true "uid" 65534) | nindent 8 }}
         args:
         - --v=5
         - --leader-election=true
@@ -84,7 +84,7 @@ spec:
             {{- include "snapshot_controller_resources" . | nindent 12 }}
             {{- end }}
       - name: kube-rbac-proxy
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true "seccompProfile" true "uid" 65534) | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
           - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8080"

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
       - name: webhooks
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true "seccompProfile" true) | nindent 8 }}
         command:
           - /webhooks
           - -tls-cert-file=/etc/webhook/certs/tls.crt


### PR DESCRIPTION
## Description

Migrate the `snapshot-controller` module to the **container-base** `v1.1.2` catalog:

- `BASE_IMAGES_VERSION` in GitHub workflows: `v0.5.79` → `v1.1.2`
- `base_images.yml` download URL: `deckhouse/base-images` → `deckhouse/container-base/base-images`
- `.werf/base-images.yaml` — simplified to `$.Images` without intermediate stages
- `.werf/bundle.yaml`, `release.yaml`, `images-digests.yaml`, `choose-edition.yaml` — `from: {{ index $.Images "..." }}`
- All images: `builder/golang` / `builder/alpine-svace`, `builder/distroless`
- `images/snapshot-controller`: `pm install git make bash` instead of `apk add` on alpine builder
- `.werf/images.yaml`: pass `Images` into `$ctx` (fix for `index $.Images`)
- `.dmtlint.yaml`: `no-cyrillic` exclusion for `hack/`
- `base_images.yml` in `.gitignore`

## Why do we need it, and what problem does it solve?

The module remained on the legacy `base-images` catalog (`v0.5.79`) with `fromImage` and intermediate stages. This diverges from `csi-nfs`, `csi-hpe`, `csi-huawei` and complicates maintenance.

## What is the expected result?

- GitHub Actions build succeeds on container-base `v1.1.2`
- Images `snapshot-controller`, `webhooks`, `go-hooks` build without runtime behavior changes
- dmtlint does not flag Cyrillic in `hack/generate_release_notes.go`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.