### PR TITLE
chore: set storage subsystem in module.yaml

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -2,7 +2,6 @@ name: snapshot-controller
 stage: "General Availability"
 subsystems:
   - storage
-  - infrastructure
 namespace: d8-snapshot-controller
 descriptions:
   en: |


### PR DESCRIPTION
## Description
Declare the `storage` subsystem in `module.yaml` by setting `subsystems: [storage]`.

## Why do we need it, and what problem does it solve?
Standardizes module metadata across all storage modules so each one consistently declares the `storage` subsystem. Modules that previously also listed `infrastructure` are normalized to `storage` only.

## What is the expected result?
`module.yaml` contains:
```yaml
subsystems:
  - storage
```
Metadata-only change; no runtime behavior is affected.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
